### PR TITLE
change delete item from lava to shears [change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ block by doing the same thing you did to create the first head.
 To edit a head you placed earlier, hold nothing and click the head with the
 wand, or shift-click the block to see a list of all the heads in the block. You
 can edit or delete heads from this list. You can alternatively delete all heads
-in the block by Left-clicking with the wand and a Lava Bucket.
+in the block by Left-clicking with the wand and a pair of Shears.
 
 To change the hitbox of the head block, press Left Click while holding the wand.
 This will toggle between a pass-through and a solid block. You can also add a

--- a/src/main/java/dev/tizu/headmate/wand/WandListener.java
+++ b/src/main/java/dev/tizu/headmate/wand/WandListener.java
@@ -78,7 +78,7 @@ public class WandListener implements Listener {
 						else
 							break;
 						return;
-					case LAVA_BUCKET:
+					case SHEARS:
 						break;
 					default:
 						player.sendActionBar(Component.text("That's not a head!", NamedTextColor.RED));
@@ -101,7 +101,7 @@ public class WandListener implements Listener {
 						}
 						handleRayClick(event);
 						break;
-					case LAVA_BUCKET: // this falls through from above, too
+					case SHEARS: // this falls through from above, too
 						handleRayClickDeletion(event);
 						break;
 					default:
@@ -113,7 +113,7 @@ public class WandListener implements Listener {
 
 			case LEFT_CLICK_BLOCK:
 				switch (offhand.getType()) {
-					case LAVA_BUCKET:
+					case SHEARS:
 						if (!HeadmateStore.has(block)) {
 							player.sendActionBar(Component.text("Nothing to remove!", NamedTextColor.RED));
 							return;
@@ -131,13 +131,13 @@ public class WandListener implements Listener {
 						}
 					default:
 						player.sendActionBar(Component.text(
-								"Hold lava (to delete) or nothing (change hitbox) in offhand",
+								"Hold shears (to delete) or nothing (change hitbox) in offhand",
 								NamedTextColor.RED));
 						return;
 				}
 				break;
 			case LEFT_CLICK_AIR:
-				if (offhand.getType() != Material.LAVA_BUCKET || !player.hasPermission("headmate.wand.reload.use"))
+				if (offhand.getType() != Material.SHEARS || !player.hasPermission("headmate.wand.reload.use"))
 					return;
 				ThisPlugin.i().reloadConfig();
 				player.sendActionBar(Component.text("Config reloaded!", NamedTextColor.GREEN));


### PR DESCRIPTION
less annoying on the client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed the item used to trigger wand actions from lava bucket to shears for all relevant player interactions. User feedback messages and permissions now reference shears instead of lava buckets.
* **Documentation**
  * Updated instructions to reflect that deleting all heads is done using shears instead of a lava bucket.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->